### PR TITLE
Added globaltoc sidebar option

### DIFF
--- a/guzzle_sphinx_theme/guzzle_sphinx_theme/globaltoc.html
+++ b/guzzle_sphinx_theme/guzzle_sphinx_theme/globaltoc.html
@@ -1,0 +1,10 @@
+{%- if display_toc %}
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3><a href="{{ pathto(master_doc) }}">{{ _('Table Of Contents') }}</a></h3>
+  </div>
+  <div class="panel-body panel-toc panel-globaltoc">
+    {{ toctree() }}
+  </div>
+</div>
+{%- endif %}


### PR DESCRIPTION
Previously if you include the sphinx built-in “globaltoc” it comes out completely unformatted.
