### PR TITLE
Fix python 3 issue

### DIFF
--- a/guzzle_sphinx_theme/__init__.py
+++ b/guzzle_sphinx_theme/__init__.py
@@ -34,7 +34,7 @@ def create_sitemap(app, exception):
         return
 
     filename = app.outdir + "/sitemap.xml"
-    print "Generating sitemap.xml in %s" % filename
+    print("Generating sitemap.xml in %s" % filename)
 
     root = ET.Element("urlset")
     root.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")


### PR DESCRIPTION
I can confirm that I am now able to generate docs on python 3 using the theme.