### PR TITLE
Updating field-list to not use a table layout.

### DIFF
--- a/demo/index.rst
+++ b/demo/index.rst
@@ -7,6 +7,7 @@ Guzzle Sphinx Theme Demo
 
     page-1
     table-with-code
+    pymethod
 
 
 Check this out
@@ -24,3 +25,18 @@ Another list
 * dolor lorem ipsum
 * lorem ipsum dolor
 * dolor lorem ipsum
+
+
+Some definitions
+----------------
+
+Donec sodales
+    velit ac sagittis fermentum, metus ante pharetra ex, ac eleifend
+    erat ligula in lacus. Donec tincidunt urna est, non mollis turpis lacinia
+
+sit amet
+    Duis ac facilisis libero, ut interdum nibh. Sed rutrum dapibus pharetra.
+
+Ut ac luctus nisi
+    vitae volutpat arcu. Vivamus venenatis eu nibh ut consectetur. Cras
+    tincidunt dui nisi, et facilisis eros feugiat nec.

--- a/demo/pymethod.rst
+++ b/demo/pymethod.rst
@@ -1,0 +1,129 @@
+==============
+Python Methods
+==============
+
+.. contents:: Table of Contents
+   :depth: 2
+
+.. py:function:: send_message(sender, recipient, message_body, [priority=1])
+
+   Send a message to a recipient
+
+   :param str sender: The person sending the message
+   :param str recipient: The recipient of the message
+   :param str message_body: The body of the message
+   :param priority: The priority of the message, can be a number 1-5
+   :type priority: integer or None
+   :return: the message id
+   :rtype: int
+   :raises ValueError: if the message_body exceeds 160 characters
+   :raises TypeError: if the message_body is not a basestring
+
+
+Client
+------
+
+.. py:class:: Foo.Client
+
+  Lorem ipsum dolor. Lorem ipsum dolor::
+
+    client = foo.create_client('baz')
+
+  Available methods:
+
+  * :py:meth:`bar`
+
+.. py:method:: bar(**kwargs)
+
+  Lorem ipsum dolor. Lorem ipsum dolor.
+
+  **Request Syntax**
+
+  ::
+
+      response = client.accept_vpc_peering_connection(
+          DryRun=True|False,
+          VpcPeeringConnectionId='string'
+      )
+
+  :type DryRun: boolean
+  :param DryRun:
+
+      Checks whether you have the required permissions for the action, without
+      actually making the request, and provides an error response. If you have
+      the required permissions, the error response is ``DryRunOperation``.
+      Otherwise, it is ``UnauthorizedOperation``.
+
+  :type VpcPeeringConnectionId: string
+  :param VpcPeeringConnectionId:
+
+    The ID of the VPC peering connection.
+
+  :rtype: dict
+  :returns:
+
+      **Response Syntax**
+
+      ::
+
+          {
+              'VpcPeeringConnection': {
+                  'AccepterVpcInfo': {
+                      'CidrBlock': 'string',
+                      'OwnerId': 'string',
+                      'VpcId': 'string'
+                  },
+                  'ExpirationTime': datetime(2015, 1, 1),
+                  'RequesterVpcInfo': {
+                      'CidrBlock': 'string',
+                      'OwnerId': 'string',
+                      'VpcId': 'string'
+                  },
+                  'Status': {
+                      'Code': 'string',
+                      'Message': 'string'
+                  },
+                  'Tags': [
+                      {
+                          'Key': 'string',
+                          'Value': 'string'
+                      },
+                  ],
+                  'VpcPeeringConnectionId': 'string'
+              }
+          }
+
+      **Response Structure**
+
+      - *(dict) --*
+
+        - **VpcPeeringConnection** *(dict) --* Information about the VPC peering connection.
+
+          - **AccepterVpcInfo** *(dict) --* The information of the peer VPC.
+
+            - **CidrBlock** *(string) --* The CIDR block for the VPC.
+
+              - **OwnerId** *(string) --* The AWS account ID of the VPC owner.
+              - **VpcId** *(string) --* The ID of the VPC.
+              - **ExpirationTime** *(datetime) --* The time that an unaccepted VPC peering connection will expire.
+              - **RequesterVpcInfo** *(dict) --* The information of the requester VPC.
+
+                - **CidrBlock** *(string) --* The CIDR block for the VPC.
+                - **OwnerId** *(string) --* The AWS account ID of the VPC owner.
+                - **VpcId** *(string) --* The ID of the VPC.
+                - **Status** *(dict) --* The status of the VPC peering connection.
+                - **Code** *(string) --* The status of the VPC peering connection.
+                - **Message** *(string) --* A message that provides more information about the status, if applicable.
+                - **Tags** *(list) --* Any tags assigned to the resource.
+
+                  - *(dict) --* Describes a tag.
+
+                    - **Key** *(string) --* The key of the tag.
+
+                        Constraints: Tag keys are case-sensitive and accept a maximum of 127 Unicode characters. May not begin with ``aws:``
+
+                    - **Value** *(string) --* The value of the tag.
+
+                        Constraints: Tag values are case-sensitive and accept a maximum of 255 Unicode characters.
+
+                    - **VpcPeeringConnectionId** *(string) --* The ID of the VPC peering connection.

--- a/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
+++ b/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
@@ -48,6 +48,10 @@ dt:hover > a.headerlink {
   visibility: visible;
 }
 
+h1 > a, h2 > a, h3 > a, h4 > a, h5 > a, h6 > a {
+  color: #5C7C98;
+}
+
 h1, h2, h3, h4, h5, h6 {
   color: black;
   font-weight: normal;
@@ -590,6 +594,10 @@ div.topic.contents {
     display: inline-block;
     border-radius: 3px;
     padding: 24px 36px 18px 36px;
+}
+
+div.topic.contents > ul {
+    padding-left: 20px;
 }
 
 /* -- admonitions ----------------------------------------------------------- */

--- a/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
+++ b/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
@@ -70,7 +70,6 @@ h1 {
 }
 
 h2 {
-  margin-top: 40px;
   font-size: 34px;
   padding: .2em 0;
   border-bottom: 1px solid #ddd;
@@ -105,7 +104,6 @@ div.related {
 }
 
 p {
-  margin: 1.2em 0;
   padding: 0;
   font-family: inherit;
   font-size: inherit;
@@ -156,7 +154,7 @@ a.internal em {
 }
 
 dl dd {
-  margin: 3px 0 10px 40px;
+  margin: 3px 0 10px 30px;
 }
 
 .breadcrumb {


### PR DESCRIPTION
This commit updates method, class, param field list domains to no longer
use a table but instead use dt/dl elements. This allows for massively
long strings in these values without wonky table alignment issues.

![screen shot 2015-06-24 at 4 28 14 pm](https://cloud.githubusercontent.com/assets/190930/8343783/0d7ee112-1a8e-11e5-8d2a-6e7093e4e308.png)

@jamesls @kyleknap 