### PR TITLE
fix name of extrahead block in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Finally, edit your override file "source/_templates/layout.html":
     {# Import the theme's layout. #}
     {% extends "!layout.html" %}
 
-    {%- block extra_head %}
+    {%- block extrahead %}
     {# Add custom things to the head HTML tag #}
     {# Call the parent block #}
     {{ super() }}


### PR DESCRIPTION
The README was referencing the `extrahead` block in the `layout.html` file as `extra_head`, which doesn't match the source template.