### PR TITLE
Support for code-block captions

### DIFF
--- a/guzzle_sphinx_theme/__init__.py
+++ b/guzzle_sphinx_theme/__init__.py
@@ -136,3 +136,6 @@ class HTMLTranslator(SphinxHTMLTranslator):
     def depart_field_list(self, node):
         self.body.append('</dl>\n')
         self.compact_field_list, self.compact_p = self.context.pop()
+
+    def visit_container(self, node):
+        self.body.append(self.starttag(node, 'div', CLASS='docutils'))

--- a/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
+++ b/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
@@ -791,15 +791,18 @@ dt:target, .highlight {
 /* -- code displays --------------------------------------------------------- */
 
 .code-block-caption {
-  border-width: 0 0 0 2px;
-  border-color: #eee;
-  border-style: solid;
-  padding: 14px 0 0 20px;
   margin-bottom: -20px;
+}
+
+.code-block-caption .caption-text {
+  display: inline-block;
+  padding: 6px 20px;
   font-weight: bold;
   font-size: 18px;
   line-height: 1.1;
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #fff;
+  background-color: #337ab7;
 }
 
 td.linenos pre {

--- a/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
+++ b/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
@@ -41,7 +41,8 @@ h3:hover > a.headerlink,
 h4:hover > a.headerlink,
 h5:hover > a.headerlink,
 h6:hover > a.headerlink,
-dt:hover > a.headerlink {
+dt:hover > a.headerlink,
+.code-block-caption:hover > a.headerlink {
   visibility: visible;
 }
 
@@ -788,6 +789,18 @@ dt:target, .highlight {
 }
 
 /* -- code displays --------------------------------------------------------- */
+
+.code-block-caption {
+  border-width: 0 0 0 2px;
+  border-color: #eee;
+  border-style: solid;
+  padding: 14px 0 0 20px;
+  margin-bottom: -20px;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 1.1;
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
 
 td.linenos pre {
   padding: 5px 0px;


### PR DESCRIPTION
Source:
```rst
.. code-block:: xml
   :caption: navigation

    <plug plugin="navigation" name="main-navigation">
      <config xmlns="http://example.com/example.com/acme-inc/framework/plugin/navigation/config">
        <depth min="4" max="4"/>
      </config>
    </plug>
```

Before:
![screenshot_20180719_160010](https://user-images.githubusercontent.com/343404/42947136-efc392b4-8b6c-11e8-9396-d450c74c9e88.png)

After:
![screenshot_20180720_131544](https://user-images.githubusercontent.com/343404/42999684-10f66af8-8c1f-11e8-85fc-7e89297a2eb7.png)
