### PR TITLE
Provide entry_points for loading the theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,7 @@ Add the following to your conf.py:
 
 .. code-block:: python
 
-    import guzzle_sphinx_theme
-
-    html_theme_path = guzzle_sphinx_theme.html_theme_path()
     html_theme = 'guzzle_sphinx_theme'
-
-    # Register the theme as an extension to generate a sitemap.xml
-    extensions.append("guzzle_sphinx_theme")
 
     # Guzzle theme options (see theme.conf for more information)
     html_theme_options = {
@@ -41,13 +35,7 @@ example shows:
 
 .. code-block:: python
 
-    import guzzle_sphinx_theme
-
-    html_theme_path = guzzle_sphinx_theme.html_theme_path()
     html_theme = 'guzzle_sphinx_theme'
-
-    # Register the theme as an extension to generate a sitemap.xml
-    extensions.append("guzzle_sphinx_theme")
 
     # Guzzle theme options (see theme.conf for more information)
     html_theme_options = {

--- a/guzzle_sphinx_theme/__init__.py
+++ b/guzzle_sphinx_theme/__init__.py
@@ -14,10 +14,18 @@ from pygments.token import Keyword, Name, Comment, String, Error, \
 
 def setup(app):
     """Setup conntects events to the sitemap builder"""
+    app.require_sphinx('1.6')  # For add_html_theme()
+    app.add_html_theme(
+        'guzzle_sphinx_theme',
+        os.path.abspath(os.path.join(os.path.dirname(__file__),
+                        'guzzle_sphinx_theme')))
     app.connect('html-page-context', add_html_link)
     app.connect('build-finished', create_sitemap)
     app.set_translator('html', HTMLTranslator)
     app.sitemap_links = []
+    return {
+        'parallel_read_safe': True,
+    }
 
 
 def add_html_link(app, pagename, templatename, context, doctree):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://github.com/guzzle/guzzle_sphinx_theme',
     packages=['guzzle_sphinx_theme'],
     include_package_data=True,
-    install_requires=['Sphinx>1.3'],
+    install_requires=['Sphinx>=1.6'],
     license="MIT",
     classifiers=(
         'Development Status :: 3 - Alpha',
@@ -19,4 +19,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
     ),
+    entry_points={
+        'sphinx.html_themes': [
+            'guzzle_sphinx_theme = guzzle_sphinx_theme',
+        ]
+    },
 )


### PR DESCRIPTION
This makes using the theme much easier, see updated usage examples.
Especially, it's not necessary anymore to add the module to `extensions`, but `sitemap.xml` is generated anyway.